### PR TITLE
#81 updated to queen-antlr 0.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 		<dependency>
 			<groupId>org.queenlang</groupId>
 			<artifactId>queen-antlr</artifactId>
-			<version>0.0.6</version>
+			<version>0.0.7</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.javaparser</groupId>

--- a/src/main/java/org/queenlang/transpiler/QueenParseTreeVisitor.java
+++ b/src/main/java/org/queenlang/transpiler/QueenParseTreeVisitor.java
@@ -245,6 +245,9 @@ public final class QueenParseTreeVisitor extends QueenParserBaseVisitor<QueenNod
 
     @Override
     public ModifierNode visitClassAbstractOrFinal(QueenParser.ClassAbstractOrFinalContext ctx) {
+        if(ctx == null) {
+            return new QueenModifierNode(getPosition(ctx), "final");
+        }
         return new QueenModifierNode(getPosition(ctx), asString(ctx));
     }
 

--- a/src/test/resources/queenToJava/real/self-web/JsonContract.java
+++ b/src/test/resources/queenToJava/real/self-web/JsonContract.java
@@ -8,6 +8,8 @@ import java.util.Locale;
 
 public final class JsonContract extends AbstractJsonObject {
 
+    private final String charset = "UTF-8";
+
     public JsonContract(final Contract contract) {
         this(contract, Boolean.FALSE);
     }

--- a/src/test/resources/queenToJava/real/self-web/JsonContract.queen
+++ b/src/test/resources/queenToJava/real/self-web/JsonContract.queen
@@ -7,13 +7,14 @@ import java.math.BigDecimal;
 import java.text.NumberFormat;
 import java.util.Locale;
 
-public final implementation JsonContract extends AbstractJsonObject {
+public implementation JsonContract extends AbstractJsonObject {
+    private final String charset = "UTF-8";
 
-    public JsonContract(Contract contract) {
+    public JsonContract(final Contract contract) {
         this(contract, Boolean.FALSE);
     }
 
-    public JsonContract(Contract contract, boolean withWalletType) {
+    public JsonContract(final Contract contract, final boolean withWalletType) {
         super(
             () -> {
                 if(withWalletType) {


### PR DESCRIPTION
fixes #81 

* implementations are final by default, if ``final`` or ``abstract`` are missing;
* fields and parameters can also be ``final`` even though the keyword is redundant, since that's the default behaviour;